### PR TITLE
Find Parquet columns by name

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetColumnIOConverter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetColumnIOConverter.java
@@ -30,9 +30,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
+import static com.twitter.presto.parquet.ParquetTypeUtils.findColumnIObyName;
 import static io.prestosql.parquet.ParquetTypeUtils.getArrayElementColumn;
 import static io.prestosql.parquet.ParquetTypeUtils.getMapKeyValueColumn;
-import static io.prestosql.parquet.ParquetTypeUtils.lookupColumnByName;
 import static io.prestosql.spi.type.StandardTypes.ARRAY;
 import static io.prestosql.spi.type.StandardTypes.MAP;
 import static io.prestosql.spi.type.StandardTypes.ROW;
@@ -61,7 +61,7 @@ final class ParquetColumnIOConverter
             for (int i = 0; i < fields.size(); i++) {
                 NamedTypeSignature namedTypeSignature = fields.get(i).getNamedTypeSignature();
                 String name = namedTypeSignature.getName().get().toLowerCase(Locale.ENGLISH);
-                Optional<Field> field = constructField(parameters.get(i), lookupColumnByName(groupColumnIO, name));
+                Optional<Field> field = constructField(parameters.get(i), findColumnIObyName(groupColumnIO, name));
                 structHasParameters |= field.isPresent();
                 fieldsBuilder.add(field);
             }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSource.java
@@ -38,8 +38,8 @@ import java.util.Optional;
 import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkState;
-import static io.prestosql.parquet.ParquetTypeUtils.getFieldIndex;
-import static io.prestosql.parquet.ParquetTypeUtils.lookupColumnByName;
+import static com.twitter.presto.parquet.ParquetTypeUtils.findColumnIObyName;
+import static com.twitter.presto.parquet.ParquetTypeUtils.findFieldIndexByName;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
@@ -107,7 +107,7 @@ public class ParquetPageSource
             }
             else {
                 String columnName = useParquetColumnNames ? name : fileSchema.getFields().get(column.getHiveColumnIndex()).getName();
-                fieldsBuilder.add(constructField(type, lookupColumnByName(messageColumnIO, columnName)));
+                fieldsBuilder.add(constructField(type, findColumnIObyName(messageColumnIO, columnName)));
             }
         }
         types = typesBuilder.build();
@@ -161,7 +161,7 @@ public class ParquetPageSource
                     Optional<Field> field = fields.get(fieldId);
                     int fieldIndex;
                     if (useParquetColumnNames) {
-                        fieldIndex = getFieldIndex(fileSchema, columnNames.get(fieldId));
+                        fieldIndex = findFieldIndexByName(fileSchema, columnNames.get(fieldId));
                     }
                     else {
                         fieldIndex = hiveColumnIndexes[fieldId];

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -60,10 +60,10 @@ import java.util.Properties;
 import java.util.Set;
 
 import static com.google.common.base.Strings.nullToEmpty;
+import static com.twitter.presto.parquet.ParquetTypeUtils.findParquetTypeByName;
 import static io.prestosql.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.prestosql.parquet.ParquetTypeUtils.getColumnIO;
 import static io.prestosql.parquet.ParquetTypeUtils.getDescriptors;
-import static io.prestosql.parquet.ParquetTypeUtils.getParquetTypeByName;
 import static io.prestosql.parquet.predicate.PredicateUtils.buildPredicate;
 import static io.prestosql.parquet.predicate.PredicateUtils.predicateMatches;
 import static io.prestosql.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
@@ -258,7 +258,7 @@ public class ParquetPageSourceFactory
     public static org.apache.parquet.schema.Type getParquetType(HiveColumnHandle column, MessageType messageType, boolean useParquetColumnNames)
     {
         if (useParquetColumnNames) {
-            return getParquetTypeByName(column.getName(), messageType);
+            return findParquetTypeByName(column.getName(), messageType);
         }
 
         if (column.getHiveColumnIndex() < messageType.getFieldCount()) {

--- a/presto-parquet/src/main/java/com/twitter/presto/parquet/ParquetTypeUtils.java
+++ b/presto-parquet/src/main/java/com/twitter/presto/parquet/ParquetTypeUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.presto.parquet;
+
+import org.apache.parquet.io.ColumnIO;
+import org.apache.parquet.io.GroupColumnIO;
+import org.apache.parquet.schema.MessageType;
+
+import static io.prestosql.parquet.ParquetTypeUtils.getFieldIndex;
+import static io.prestosql.parquet.ParquetTypeUtils.getParquetTypeByName;
+import static io.prestosql.parquet.ParquetTypeUtils.lookupColumnByName;
+
+public class ParquetTypeUtils
+{
+    private ParquetTypeUtils()
+    {
+    }
+
+    /**
+     * Find the column type by name using returning the first match with the following logic:
+     * <ul>
+     * <li>direct match</li>
+     * <li>case-insensitive match</li>
+     * <li>if the name ends with _, remove it and direct match</li>
+     * <li>if the name ends with _, remove it and case-insensitive match</li>
+     * </ul>
+     */
+    public static org.apache.parquet.schema.Type findParquetTypeByName(String name, MessageType messageType)
+    {
+        org.apache.parquet.schema.Type type = getParquetTypeByName(name, messageType);
+
+        if (type == null && name.endsWith("_")) {
+            type = getParquetTypeByName(name.substring(0, name.length() - 1), messageType);
+        }
+        return type;
+    }
+
+    // Find the column index by name following the same logic as findParquetTypeByName
+    public static int findFieldIndexByName(MessageType fileSchema, String name)
+    {
+        int fieldIndex = getFieldIndex(fileSchema, name);
+
+        if (fieldIndex == -1 && name.endsWith("_")) {
+            fieldIndex = getFieldIndex(fileSchema, name.substring(0, name.length() - 1));
+        }
+
+        return fieldIndex;
+    }
+
+    // Find the ColumnIO by name following the same logic as findParquetTypeByName
+    public static ColumnIO findColumnIObyName(GroupColumnIO groupColumnIO, String name)
+    {
+        ColumnIO columnIO = lookupColumnByName(groupColumnIO, name);
+
+        if (columnIO == null && name.endsWith("_")) {
+            columnIO = lookupColumnByName(groupColumnIO, name.substring(0, name.length() - 1));
+        }
+
+        return columnIO;
+    }
+}


### PR DESCRIPTION
Find the column type by name using returning the first match with the following logic:
* direct match
* case-insensitive match
* if the name ends with _, remove it and direct match
* if the name ends with _, remove it and case-insensitive match